### PR TITLE
fix: prevent query parameter injection in simih

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -28,7 +28,7 @@ const wait = async (media) => new Promise(async (resolve, reject) => {
 
 const simih = async (text) => {
 	try {
-		const sami = await fetch(`https://simsumi.herokuapp.com/api?text=${text}`, {method: 'GET'})
+		const sami = await fetch(`https://simsumi.herokuapp.com/api?text=${encodeURIComponent(text)}`, {method: 'GET'})
 		const res = await sami.json()
 		return res.success
 	} catch {


### PR DESCRIPTION
## Summary
Encode user-controlled input in `simih()` before constructing the external API URL.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | Low/Medium |
| **File** | `lib/functions.js` |

**Description**: `simih()` interpolated the caller-controlled `text` value directly
into the `text` query parameter of an external API URL. Characters such as `&`, `=`,
and `#` could alter the resulting query structure (e.g. `hello&foo=bar` would become
`?text=hello&foo=bar` — two parameters instead of one).

**Fix**: Wrap the value with `encodeURIComponent()` so it is always treated as a
single parameter value regardless of its content.

**Scope**: This PR is intentionally limited to `lib/functions.js`. No behavior
change is intended for valid input.

## Changes
- `lib/functions.js` — `simih()`: `text` → `encodeURIComponent(text)`

## Manual Regression Test
No test infrastructure exists in this repository, so here are manual steps to verify:

| Input | Expected URL fragment |
|-------|-----------------------|
| `hello world` | `text=hello%20world` |
| `hello&foo=bar` | `text=hello%26foo%3Dbar` |
| `a=b` | `text=a%3Db` |
| `hello?x=y` | `text=hello%3Fx%3Dy` |
| `こんにちは` | `text=%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF` |

Each input should appear as a single `text` value, not as additional query parameters.